### PR TITLE
Simple correction to Docs setListBoxRows

### DIFF
--- a/docs/mkdocs/docs/pythonWidgets.md
+++ b/docs/mkdocs/docs/pythonWidgets.md
@@ -491,7 +491,7 @@ app.go()
 * `.clearListBox(title)`  
     Removes all items from the specified ListBox.  
 
-* `.setListBoxRows(title)`  
+* `.setListBoxRows(title, rows)`  
     Sets how many rows to display in the specified ListBox.  
 
 * `.setListBoxMulti(list, multi=True)`  


### PR DESCRIPTION
I found this simple mistake in the docs.

The actual function takes a title and the number of rows to display

https://github.com/jarvisteach/appJar/blob/next_release/appJar/appjar.py#L5125