### PR TITLE
Correct the Properties tab in showcase.py

### DIFF
--- a/appJar/examples/showcase.py
+++ b/appJar/examples/showcase.py
@@ -214,14 +214,14 @@ with gui("ShowCase") as app:
 
         with app.tab("Properties"):
             with app.panedFrame("left"):
+                app.label("f","Font")
                 app.label("t", "Transparency")
                 app.label("t2", "Transparency")
-                app.label("f","Font")
 
                 with app.panedFrame("right"):
-                    app.slider("TransparencyScale", 100, change=scale, interval=25)
+                    app.slider("FontScale", value=12, show=True, change=scale, range=(6,40))
+                    app.slider("TransparencyScale", value=100, show=True, change=scale, interval=25)
                     app.spin("TransparencySpin", value=0, endValue=100, item='100', change=scale)
-                    app.slider("FontScale", 12, show=True, change=scale, range=(6,40))
 
         with app.tab("Meters"):
             app.meter("Meter1", fill="Yellow")


### PR DESCRIPTION
In the Properties tab of showcase:

1- FontScale slider setup value as positinal argument was not taken into account (got lost in the new functions for v1.0 I guess). I made it a keyword argument and the slider is correctly positionned now.

2- Same for the TransparencyScale slider that was positioned at 0 instaed of 100.

3- There is a mismatch between inputs widgets and their labels, respectively in the right and left panedFrames. For a reason I ignore, the FontScale slider was displayed at the top of the right paned frame, while the coresponding label was at the bottom of the left panedFrame. This may have something to do with issue #301 "Not happy with layout" but I just tried appJar, created a GitHub account at last, and my time on this is up !